### PR TITLE
Rework negative matching

### DIFF
--- a/pychoir/containers.py
+++ b/pychoir/containers.py
@@ -46,8 +46,8 @@ class AreNot(Matcher):
         self.matchers = matchers
 
     def _matches(self, iterable: Iterable[Any]) -> bool:
-        return all(self.nested_match(matcher, value, inverse=True)
-                   for value in iterable for matcher in self.matchers)
+        return not any(self.nested_match(matcher, value, expect_mismatch=True)
+                       for value in iterable for matcher in self.matchers)
 
     def _description(self) -> str:
         return ', '.join(map(repr, self.matchers))

--- a/pychoir/logical.py
+++ b/pychoir/logical.py
@@ -39,7 +39,7 @@ class Not(Matcher):
         self.matchers = matchers
 
     def _matches(self, other: Any) -> bool:
-        return all(self.nested_match(matcher, other, inverse=True) for matcher in self.matchers)
+        return not any(self.nested_match(matcher, other, expect_mismatch=True) for matcher in self.matchers)
 
     def _description(self) -> str:
         return ', '.join(map(repr, self.matchers))

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -57,14 +57,14 @@ class TestMatcher:
         assert str(matching_matcher) == '_TestMatcher(does_match=True)'
         assert Anything().nested_match(matching_matcher, 1)
         assert str(matching_matcher) == '_TestMatcher(does_match=True)'
-        assert not Anything().nested_match(matching_matcher, 1, inverse=True)
+        assert Anything().nested_match(matching_matcher, 1, expect_mismatch=True)
         assert str(matching_matcher) == '_TestMatcher(does_match=True)[FAILED for 1]'
-        assert not Anything().nested_match(matching_matcher, 2, inverse=True)
+        assert Anything().nested_match(matching_matcher, 2, expect_mismatch=True)
         assert str(matching_matcher) == '_TestMatcher(does_match=True)[FAILED for (1, 2)]'
 
         mismatching_matcher = self._TestMatcher(False)
         assert str(mismatching_matcher) == '_TestMatcher(does_match=False)'
-        assert Anything().nested_match(mismatching_matcher, 3, inverse=True)
+        assert not Anything().nested_match(mismatching_matcher, 3, expect_mismatch=True)
         assert str(mismatching_matcher) == '_TestMatcher(does_match=False)'
         assert not Anything().nested_match(mismatching_matcher, 3)
         assert str(mismatching_matcher) == '_TestMatcher(does_match=False)[FAILED for 3]'
@@ -72,9 +72,9 @@ class TestMatcher:
         assert str(mismatching_matcher) == '_TestMatcher(does_match=False)[FAILED for (3, 4)]'
 
         assert Anything().nested_match(1, 1)
-        assert not Anything().nested_match(1, 1, inverse=True)
+        assert Anything().nested_match(1, 1, expect_mismatch=True)
         assert not Anything().nested_match(1, 2)
-        assert Anything().nested_match(1, 2, inverse=True)
+        assert not Anything().nested_match(1, 2, expect_mismatch=True)
 
     @patch('warnings.warn')
     def test_warn_when_reusing(self, warn_mock: MagicMock) -> None:

--- a/tests/test_logical.py
+++ b/tests/test_logical.py
@@ -1,7 +1,13 @@
+from contextlib import contextmanager
+from typing import Iterator
+from unittest.mock import patch
+
 from pychoir import (
+    NE,
     AllOf,
     And,
     AnyOf,
+    EqualTo,
     GreaterThan,
     HasLength,
     IsInstance,
@@ -40,6 +46,156 @@ def test_not():
     assert not [1] == [IsNoneOf(0, 1, 2)]
 
     assert str([Not(0, 1, 2)]) == '[Not(0, 1, 2)]'
+
+
+def test_not_or():
+    @contextmanager
+    def make_not_or_123() -> Iterator[Not]:
+        yield Not(Or(EqualTo(1), 2, 3))
+
+    with make_not_or_123() as not_or_123:
+        assert 4 == not_or_123
+        assert str(not_or_123) == 'Not(Or(EqualTo(1), 2, 3))'
+
+    with make_not_or_123() as not_or_123:
+        assert not 4 != not_or_123
+        assert str(not_or_123) == 'Not(Or(EqualTo(1)[FAILED for 4], 2, 3)[FAILED for 4])[FAILED for 4]'
+
+    with make_not_or_123() as not_or_123:
+        with patch('warnings.warn'):  # Suppress warnings from using the same matcher many times
+            for i in (1, 2, 3):
+                assert i != not_or_123
+        assert str(not_or_123) == 'Not(Or(EqualTo(1)[FAILED for (2, 3)], 2, 3))'
+
+    with make_not_or_123() as not_or_123:
+        with patch('warnings.warn'):  # Suppress warnings from using the same matcher many times
+            for i in (1, 2, 3):
+                assert not i == not_or_123
+        assert str(not_or_123) == 'Not(Or(EqualTo(1)[FAILED for 1], 2, 3)[FAILED for (1, 2, 3)])[FAILED for (1, 2, 3)]'
+
+
+def test_not_not():
+    @contextmanager
+    def make_not_one() -> Iterator[Not]:
+        yield Not(1)
+
+    with make_not_one() as not_one:
+        assert 2 == not_one
+        assert str(not_one) == 'Not(1)'
+
+    with make_not_one() as not_one:
+        assert 1 != not_one
+        assert str(not_one) == 'Not(1)'
+
+    with make_not_one() as not_one:
+        assert not 2 != not_one
+        assert str(not_one) == 'Not(1)[FAILED for 2]'
+
+    with make_not_one() as not_one:
+        assert not 1 == not_one
+        assert str(not_one) == 'Not(1)[FAILED for 1]'
+
+    @contextmanager
+    def make_not_eq_one() -> Iterator[Not]:
+        yield Not(EqualTo(1))
+
+    with make_not_eq_one() as not_eq_one:
+        assert 2 == not_eq_one
+        assert str(not_eq_one) == 'Not(EqualTo(1))'
+
+    with make_not_eq_one() as not_eq_one:
+        assert 1 != not_eq_one
+        assert str(not_eq_one) == 'Not(EqualTo(1))'
+
+    with make_not_eq_one() as not_eq_one:
+        assert not 2 != not_eq_one
+        assert str(not_eq_one) == 'Not(EqualTo(1)[FAILED for 2])[FAILED for 2]'
+
+    with make_not_eq_one() as not_eq_one:
+        assert not 1 == not_eq_one
+        assert str(not_eq_one) == 'Not(EqualTo(1)[FAILED for 1])[FAILED for 1]'
+
+    @contextmanager
+    def make_not_not_one() -> Iterator[Not]:
+        yield Not(Not(1))
+
+    with make_not_not_one() as not_not_one:
+        assert 1 == not_not_one
+        assert str(not_not_one) == 'Not(Not(1))'
+
+    with make_not_not_one() as not_not_one:
+        assert 2 != not_not_one
+        assert str(not_not_one) == 'Not(Not(1))'
+
+    with make_not_not_one() as not_not_one:
+        assert not 1 != not_not_one
+        assert str(not_not_one) == 'Not(Not(1)[FAILED for 1])[FAILED for 1]'
+
+    with make_not_not_one() as not_not_one:
+        assert not 2 == not_not_one
+        assert str(not_not_one) == 'Not(Not(1)[FAILED for 2])[FAILED for 2]'
+
+    @contextmanager
+    def make_not_ne_one() -> Iterator[Not]:
+        yield Not(NE(1))
+
+    with make_not_ne_one() as not_ne_one:
+        assert 1 == not_ne_one
+        assert str(not_ne_one) == 'Not(NotEqualTo(1))'
+
+    with make_not_ne_one() as not_ne_one:
+        assert 2 != not_ne_one
+        assert str(not_ne_one) == 'Not(NotEqualTo(1))'
+
+    with make_not_ne_one() as not_ne_one:
+        assert not 1 != not_ne_one
+        assert str(not_ne_one) == 'Not(NotEqualTo(1)[FAILED for 1])[FAILED for 1]'
+
+    with make_not_ne_one() as not_ne_one:
+        assert not 2 == not_ne_one
+        assert str(not_ne_one) == 'Not(NotEqualTo(1)[FAILED for 2])[FAILED for 2]'
+
+    @contextmanager
+    def make_not_not_eq_one() -> Iterator[Not]:
+        yield Not(Not(EqualTo(1)))
+
+    with make_not_not_eq_one() as not_not_eq_one:
+        assert 1 == not_not_eq_one
+        assert str(not_not_eq_one) == 'Not(Not(EqualTo(1)))'
+
+    with make_not_not_eq_one() as not_not_eq_one:
+        assert 2 != not_not_eq_one
+        assert str(not_not_eq_one) == 'Not(Not(EqualTo(1)))'
+
+    with make_not_not_eq_one() as not_not_eq_one:
+        assert not 1 != not_not_eq_one
+        assert str(not_not_eq_one) == 'Not(Not(EqualTo(1)[FAILED for 1])[FAILED for 1])[FAILED for 1]'
+
+    with make_not_not_eq_one() as not_not_eq_one:
+        assert not 2 == not_not_eq_one
+        assert str(not_not_eq_one) == 'Not(Not(EqualTo(1)[FAILED for 2])[FAILED for 2])[FAILED for 2]'
+
+    @contextmanager
+    def make_not_not_eq_one_eq_two() -> Iterator[Not]:
+        yield Not(Not(EqualTo(1), EqualTo(2)))
+
+    with make_not_not_eq_one_eq_two() as not_not_eq_one_eq_two:
+        assert 1 == not_not_eq_one_eq_two
+        assert str(not_not_eq_one_eq_two) == 'Not(Not(EqualTo(1), EqualTo(2)))'
+
+    with make_not_not_eq_one_eq_two() as not_not_eq_one_eq_two:
+        assert not 2 != not_not_eq_one_eq_two
+        assert (str(not_not_eq_one_eq_two)
+                == 'Not(Not(EqualTo(1), EqualTo(2)[FAILED for 2])[FAILED for 2])[FAILED for 2]')
+
+    with make_not_not_eq_one_eq_two() as not_not_eq_one_eq_two:
+        assert not 1 != not_not_eq_one_eq_two
+        assert (str(not_not_eq_one_eq_two)
+                == 'Not(Not(EqualTo(1)[FAILED for 1], EqualTo(2))[FAILED for 1])[FAILED for 1]')
+
+    with make_not_not_eq_one_eq_two() as not_not_eq_one_eq_two:
+        assert 2 == not_not_eq_one_eq_two
+        assert str(not_not_eq_one_eq_two) == 'Not(Not(EqualTo(1)[FAILED for 2], EqualTo(2)))'
 
 
 def test_results_true_for():


### PR DESCRIPTION
 - Now supports nesting and more accurate error reporting
 - Each Matcher on the chain returns unflipped result
 - On pass, all Matchers on the call tree/nest chain set state to PASSED
 - On failure, all Matchers on the failing subtree set state to FAILED
 - With many sub-Matchers on the same Matcher, where not all sub-Matchers need to pass to result in a pass, even in case of passing, the failing sub-Matchers set state to FAILED