### PR TITLE
Add Python versions to GHA

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -13,20 +13,39 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ['3.9']
-
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up PyPy 3.6
       uses: actions/setup-python@v2
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: pypy-3.6
+    - name: Set up PyPy 3.7
+      uses: actions/setup-python@v2
+      with:
+        python-version: pypy-3.7
+    - name: Set up Python 3.6
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.6
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip pipenv
-        pipenv install --dev --python ${{ matrix.python-version }}
-    - name: Run checks
+        pipenv install --dev --python 3.9
+    - name: Run development checks
       run: |
         pipenv run make
+    - name: Run packaging & run checks on older Pythons
+      run: |
+        pipenv run tox


### PR DESCRIPTION
Closes #33 

Does not add the aggregated code coverage, but that can be done later. At least it's now running all necessary checks.