### PR TITLE
Add that() for that assert style

### DIFF
--- a/pychoir/__init__.py
+++ b/pychoir/__init__.py
@@ -26,7 +26,7 @@ from .containers import (  # noqa: F401
     Len,
     NotPresent,
 )
-from .core import Matchable, Matcher  # noqa: F401
+from .core import Matchable, Matcher, that  # noqa: F401
 from .existential import (  # noqa: F401
     Anything,
     In,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7,12 +7,14 @@ import pytest
 from pychoir import (
     And,
     Anything,
+    EqualTo,
     GreaterThan,
     InAnyOrder,
     IsInstance,
     IsTruthy,
     Matchable,
     Matcher,
+    that,
 )
 
 
@@ -125,6 +127,14 @@ def test_matcher_in_mock_call_params():
 
     m.do_stuff_to([{'a': 1}, {'a': 2}])
     m.do_stuff_to.assert_called_once_with(InAnyOrder([{'a': 2}, {'a': 1}]))
+
+
+def test_assert_that_matches():
+    assert that(5).matches(And(EqualTo(5), IsInstance(int)))
+
+    with pytest.raises(AssertionError) as exc_info:
+        assert that(5).matches(EqualTo(4))
+    assert str(exc_info.value).split('\n')[0] == 'assert that(5).matches(EqualTo(4)[FAILED for 5])'
 
 
 if sys.version_info >= (3, 7):


### PR DESCRIPTION
`assert that(this).matches(That())`

Not sure if this is the best thing ever, but at least it eases the minds of
some people who feel weird about using matchers in `==` assertions