### PR TITLE
Remove warnings about rerunning Matchers

### DIFF
--- a/pychoir/core.py
+++ b/pychoir/core.py
@@ -1,5 +1,4 @@
 import sys
-import warnings
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
 from enum import Enum
@@ -173,9 +172,6 @@ class Matcher(ABC):
     def matches(self, other: MatchedType, context: _MatcherContext) -> bool:
         with self.__set_context(context):
             passed = self._matches(other)
-
-        if not context.nested_call and self.__state.was_already_run:
-            warnings.warn(f'Erroneous re-run of {self}. Create a new Matcher instance for each use!')
 
         reported_passed = passed if not context.mismatch_expected else not passed
         self.__state.update(reported_passed, other)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,6 +1,6 @@
 import sys
 from typing import Any, Dict, List, cast
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -86,24 +86,6 @@ class TestMatcher:
         assert Anything().nested_match(1, 1, expect_mismatch=True)
         assert not Anything().nested_match(1, 2)
         assert not Anything().nested_match(1, 2, expect_mismatch=True)
-
-    @patch('warnings.warn')
-    def test_warn_when_reusing(self, warn_mock: MagicMock) -> None:
-        instance = self._TestMatcher(True)
-        assert instance == 1
-        warn_mock.assert_not_called()
-        assert instance == 2
-        warn_mock.assert_called_once_with(
-            'Erroneous re-run of _TestMatcher(does_match=True). Create a new Matcher instance for each use!'
-        )
-
-    @patch('warnings.warn')
-    def test_nested_match_allows_reuse(self, warn_mock: MagicMock) -> None:
-        instance = self._TestMatcher(True)
-        assert Anything().nested_match(instance, 1)
-        warn_mock.assert_not_called()
-        assert Anything().nested_match(instance, 2)
-        warn_mock.assert_not_called()
 
 
 def test_matcher_in_mock_call_params():


### PR DESCRIPTION
 - This causes false alarms in some use cases
 - ...and pytest runs the match again in case of failure anyway...