### PR TITLE
Run mypy against interpreter Python version

### DIFF
--- a/pychoir/core.py
+++ b/pychoir/core.py
@@ -148,7 +148,7 @@ class Matcher(ABC):
             self.__state.add_nested_call(matcher)
             return matcher.matches(other, _MatcherContext(mismatch_expected=expect_mismatch, nested_call=True))
         else:
-            return matcher == other
+            return bool(matcher == other)
 
     @final
     def _override_name(self, name: str) -> None:

--- a/pychoir/integration.py
+++ b/pychoir/integration.py
@@ -1,5 +1,5 @@
 import sys
-from typing import Generic, TypeVar
+from typing import Any, TypeVar
 
 from pychoir.core import Matcher
 
@@ -8,15 +8,17 @@ T = TypeVar('T', contravariant=True)
 if sys.version_info >= (3, 8):
     from typing import Protocol
 
-    class MatcherLike(Protocol[T]):
+    class _MatcherLike(Protocol[T]):
         def matches(self, other: T) -> bool:
             ...  # pragma: no cover
+
+    MatcherLike = _MatcherLike[T]
 else:
-    MatcherLike = Generic
+    MatcherLike = Any
 
 
 class Matches(Matcher):
-    def __init__(self, *matchers: MatcherLike[T]):
+    def __init__(self, *matchers: MatcherLike):
         super().__init__()
         self.matchers = matchers
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,9 +3,6 @@ max-line-length = 119
 
 
 [mypy]
-# Platform configuration
-python_version = 3.8
-
 # Miscellaneous
 warn_unused_configs = True
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -42,7 +42,7 @@ class TestMatcher:
     def test_as(self):
         instance = self._TestMatcher(True)
         assert instance.as_(int) is cast(int, instance)
-        assert type(instance.as_(int)) is self._TestMatcher  # type: ignore[unreachable]
+        assert type(instance.as_(int)) is cast(int, self._TestMatcher)
         assert instance.as_(int) == 5
 
     def test_eq(self):

--- a/tox.ini
+++ b/tox.ini
@@ -5,12 +5,12 @@ envlist = py36,py37,py38,py39,pypy36,pypy37
 allowlist_externals = sh
 deps = pytest
        pytest-cov
-       mypy
        flake8
+       mypy
 commands = pytest --cov=pychoir tests
            sh -c 'python -m doctest pychoir/[!_]*.py'
-           mypy pychoir tests
            flake8 pychoir tests
+           mypy pychoir tests
 
 [testenv:pypy{36,37}]
 allowlist_externals = sh


### PR DESCRIPTION
Also:
 - changes to make mypy pass on all supported Python versions
 - run mypy last in tox since it's the slowest check