### PR TITLE
Allow Matchers in InAnyOrder in any order

### DIFF
--- a/pychoir/utils.py
+++ b/pychoir/utils.py
@@ -1,7 +1,7 @@
 """
 Useful extensions for standard library
 """
-from typing import Sequence, TypeVar, Union
+from typing import Any, Sequence, Tuple, TypeVar, Union
 
 T = TypeVar('T')
 
@@ -11,3 +11,7 @@ def sequence_or_its_only_member(sequence: Sequence[T]) -> Union[Sequence[T], T]:
         return sequence[0]
     else:
         return sequence
+
+
+def i_removed(tuple_: Tuple[Any, ...], index: Any) -> Tuple[Any, ...]:
+    return tuple_[:index] + tuple_[index + 1:]

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -1,3 +1,4 @@
+from itertools import permutations
 from typing import Any, Dict
 
 import pytest
@@ -111,9 +112,13 @@ def test_dict_contains_all_of():
 def test_in_any_order():
     assert [1, 2, 3] == InAnyOrder([3, 2, 1])
     assert [1, 2, 2] == InAnyOrder([2, 1, 2])
-    assert [1, 2, 3] == InAnyOrder([3, IsOdd(), IsEven()])
+    for matcher_permutation in permutations([lambda: 3, IsOdd, IsEven]):
+        for value_permutation in permutations([1, 2, 3]):
+            matcher_iterable = [f() for f in matcher_permutation]
+            assert value_permutation == InAnyOrder(matcher_iterable)
     assert [1, 2, 2] != InAnyOrder([1, 1, 2])
     assert [1, 2, 3] != InAnyOrder([3, 2])
+    assert [1, 2] != InAnyOrder([1, 2, 3])
     assert [1, 2, 3] != InAnyOrder([3, 2, 1, 0])
 
     assert {1, 2, 3} == InAnyOrder({3, 2, 1})

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,6 @@
 from typing import Any, List
 
-from pychoir.utils import sequence_or_its_only_member
+from pychoir.utils import i_removed, sequence_or_its_only_member
 
 
 def test_sequence_or_its_first_member():
@@ -8,3 +8,11 @@ def test_sequence_or_its_first_member():
     assert sequence_or_its_only_member(empty_list) is empty_list
     assert sequence_or_its_only_member(['only']) == 'only'
     assert sequence_or_its_only_member(('several', 'members')) == ('several', 'members')
+
+
+def test_i_removed():
+    t = (0, 1, 2, 3, 4, 5)
+    assert i_removed(t, 0) == (1, 2, 3, 4, 5)
+    assert i_removed(t, 1) == (0, 2, 3, 4, 5)
+    assert i_removed(t, 5) == (0, 1, 2, 3, 4)
+    assert i_removed(t, 6) == t


### PR DESCRIPTION
 - Previously the first matching value was used for each
 - Now Matchers that match same values will have all variations tried